### PR TITLE
Fix Add() swallowing exceptions from InsertOneAsync

### DIFF
--- a/src/MongoRepository/ReadWriteRepository.cs
+++ b/src/MongoRepository/ReadWriteRepository.cs
@@ -45,8 +45,7 @@ namespace MongoRepository
         public virtual Task Add(TEntity entity, InsertOneOptions options = null, CancellationToken cancellationToken = default)
         {
             entity = TrimStrings(entity);
-            return Collection.InsertOneAsync(entity, options, cancellationToken)
-                .ContinueWith(_ => entity, cancellationToken, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+            return Collection.InsertOneAsync(entity, options, cancellationToken);
         }
 
         public virtual Task AddRange(IEnumerable<TEntity> entities, InsertManyOptions options = null, CancellationToken cancellationToken = default)

--- a/tests/MongoRepository.Tests/ReadWriteRepositoryTests.cs
+++ b/tests/MongoRepository.Tests/ReadWriteRepositoryTests.cs
@@ -72,6 +72,16 @@ public class ReadWriteRepositoryTests : IAsyncLifetime
         Assert.Equal("   ", result!.Name);
     }
 
+    [Fact]
+    public async Task Add_DuplicateKey_ThrowsException()
+    {
+        var item = new TestItem { Id = "dup", Name = "First", Value = 1 };
+        await _repo.Add(item);
+
+        var duplicate = new TestItem { Id = "dup", Name = "Second", Value = 2 };
+        await Assert.ThrowsAsync<MongoWriteException>(() => _repo.Add(duplicate));
+    }
+
     // --- CRUD: Add ---
 
     [Fact]


### PR DESCRIPTION
## Summary

- Remove `ContinueWith` wrapper in `Add()` that silently swallowed exceptions from `InsertOneAsync`
- Return the task directly, consistent with all other repository methods (`AddRange`, `Update`, `Delete`)
- Add regression test (`Add_DuplicateKey_ThrowsException`) verifying exception propagation

Fixes #3